### PR TITLE
Improved PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: Daniel Mills <dm@e36freak.com>
 
 pkgname=meat-git
-pkgver=20130208
+pkgver=91.a98a2b8
 pkgrel=1
 pkgdesc="A simple fast AUR helper, using cower as a back end"
 arch=('i686' 'x86_64')
@@ -11,21 +11,17 @@ depends=('bash>=4.0' 'cower' 'awk')
 makedepends=('git')
 optdepends=('pacman-color: colorized output'
             'sudo: highly recommended')
-_gitroot='git://github.com/e36freak/meat.git'
-_gitname='meat'
+source=('git://github.com/e36freak/meat.git')
+md5sums=('SKIP')
 
-build() {
-  cd "$scrdir"
-  msg "Connecting to GIT server...."
+pkgver() {
+  cd meat
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
 
-  if [[ -d $_gitname ]]; then
-    cd "$_gitname" && git pull origin
-    msg "The local files are updated."
-  else
-    git clone "$_gitroot" "$_gitname"
-    cd "$_gitname"
-  fi
 
+package() {
+  cd meat
   install -m 755 -D meat "$pkgdir/usr/bin/meat"
   install -m 644 -D config "$pkgdir/usr/share/meat/config"
 }


### PR DESCRIPTION
Having only a build() function is obsolete since pacman 4.1.
Also added VCS fetching from pacman 4.1
