### PR TITLE
Allow PKGBUILD to override PKGEXT

### DIFF
--- a/meat
+++ b/meat
@@ -149,8 +149,13 @@ aur_install() {
     # check if package is explicit, or installed as a dep, install accordingly
     info 1 "Installing \`$pkg'..."
     # get PKGEXT from makepkg.conf
-    IFS= read -rd '' pkgext < <(source /etc/makepkg.conf &&
-                                printf '%s\0' "$PKGEXT")
+    if [[ -n $PKGEXT ]]; then
+      pkgext="$PKGEXT"
+    else
+      IFS= read -rd '' pkgext < <(source /etc/makepkg.conf &&
+                                  printf '%s\0' "$PKGEXT")
+    fi
+
     if [[ -z $pkgext ]]; then
       die 'error: missing /etc/makepkg.conf, or PKGEXT unset/empty'
     fi


### PR DESCRIPTION
Some packages in AUR override PKGEXT in order to speed up builds (see google-chrome). This change allows for that. The previous behavior is that meat simply prints:

"error: no package file seems to have been created"
