### PR TITLE
correct color-settings when overwritten via commandline

### DIFF
--- a/meat
+++ b/meat
@@ -744,7 +744,6 @@ if [[ -r $config_file ]]; then
     always|auto|never) :;;
     *) die "invalid value for \`color' in the config file: \`$color'";;
   esac
-  set_colors
   if [[ $nossl != [01] ]]; then
     die "invalid value for \`nossl' in the config file: \`$nossl'"
   fi
@@ -1022,6 +1021,7 @@ while (($#)); do
 done
 
 # color info
+set_colors
 if ((iscolor[0])); then
   pacman+=(--color=always)
   cower+=(--color=always) 


### PR DESCRIPTION
Color settings on the commandline weren't passed to cower and pacman correctly. This should fix it.
